### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -1,5 +1,8 @@
 name: go-test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -10,7 +13,6 @@ on:
 
   schedule:
   - cron: '30 5,17 * * 1'
-
 
 jobs:
   tests:


### PR DESCRIPTION
Potential fix for [https://github.com/apprentice-system/spf/security/code-scanning/1](https://github.com/apprentice-system/spf/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only performs read operations (e.g., checking out code and running tests), we will set `contents: read` as the minimal required permission. This ensures the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
