### PR TITLE
Update README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # spf
-[![CI](https://github.com/mailspire/spf/actions/workflows/go-test.yaml/badge.svg?branch=main)](https://github.com/mailspire/spf/actions/workflows/go-test.yaml)    [![Go Reference](https://pkg.go.dev/badge/github.com/mailspire/spf.svg)](https://pkg.go.dev/github.com/mailspire/spf)
+[![CI](https://github.com/mailspire/spf/actions/workflows/go-test.yaml/badge.svg?branch=main)](https://github.com/mailspire/spf/actions/workflows/go-test.yaml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/mailspire/spf.svg)](https://pkg.go.dev/github.com/mailspire/spf)
 
+RFC 7208 compliant Go library for parsing and evaluating SPF records.
 
-
-RFC Compliant Go library for parsing, analyzing, and evaluating SPF records
->  [!WARNING]
-> Early proof of concept. The public API compiles and returns Neutral for every input. The real decision tree is in progress.
-
+> **Warning**
+> This project is an early proof of concept. The evaluation logic is
+> incomplete and currently returns `Neutral` for all inputs.
 
 ## Installation
 ```shell
- go get github.com/mailspire/spf
+go get github.com/mailspire/spf
 ```
 
+## Usage
 
-## Quick Start
+### Checking a host
 ```go
 package main
 
@@ -31,14 +32,21 @@ func main() {
     if err != nil {
         panic(err)
     }
-    fmt.Println(res.Code) // Neutral for now
+    fmt.Println(res.Code)
 }
 ```
 
+### Parsing a record
+```go
+rec, err := spf.Parse("v=spf1 ip4:203.0.113.0/24 -all")
+if err != nil {
+    // handle parse error
+}
+fmt.Printf("%+v\n", rec)
+```
 
 ## Contributing
 Please feel free to submit issues, fork the repository and send pull requests!
-
 
 ## License
 This project is licensed under the terms of the MIT license.


### PR DESCRIPTION
## Summary
- refresh README to reflect current examples
- add usage instructions for parsing SPF records
- clarify that this is a proof-of-concept implementation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686470fa081483228034d3c8301d2c8d